### PR TITLE
Removes package.toml

### DIFF
--- a/package.toml
+++ b/package.toml
@@ -1,2 +1,0 @@
-[buildpack]
-uri = "build/buildpack.tgz"


### PR DESCRIPTION
Since pack v0.18.0, we have been able to package buildpacks into buildpackages without a `package.toml`

Included in https://github.com/paketo-buildpacks/github-config/pull/250 was a modification to the `scripts/package.sh` behavior to use this new functionality. This means that the `package.toml` files now serve no purpose.