### PR TITLE
Bumps buildpack API to 0.6

### DIFF
--- a/build.go
+++ b/build.go
@@ -20,6 +20,7 @@ func Build(logger scribe.Logger) packit.BuildFunc {
 					{
 						Type:    "web",
 						Command: command,
+						Default: true,
 					},
 				},
 			},

--- a/build_test.go
+++ b/build_test.go
@@ -2,7 +2,6 @@ package thin_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,13 +27,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		layersDir, err = ioutil.TempDir("", "layers")
+		layersDir, err = os.MkdirTemp("", "layers")
 		Expect(err).NotTo(HaveOccurred())
 
-		cnbDir, err = ioutil.TempDir("", "cnb")
+		cnbDir, err = os.MkdirTemp("", "cnb")
 		Expect(err).NotTo(HaveOccurred())
 
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
 		buffer = bytes.NewBuffer(nil)
@@ -75,6 +74,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					{
 						Type:    "web",
 						Command: `bundle exec thin -p "${PORT:-3000}" start`,
+						Default: true,
 					},
 				},
 			},

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/thin"

--- a/detect_test.go
+++ b/detect_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"io/ioutil"
-
 	"github.com/paketo-buildpacks/packit"
 	"github.com/paketo-buildpacks/thin"
 	"github.com/paketo-buildpacks/thin/fakes"
@@ -27,10 +25,10 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(filepath.Join(workingDir, "Gemfile"), []byte{}, 0644)
+		err = os.WriteFile(filepath.Join(workingDir, "Gemfile"), []byte{}, 0600)
 		Expect(err).NotTo(HaveOccurred())
 
 		gemfileParser = &fakes.Parser{}

--- a/gemfile_parser_test.go
+++ b/gemfile_parser_test.go
@@ -1,7 +1,6 @@
 package thin_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -20,7 +19,7 @@ func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		file, err := ioutil.TempFile("", "Gemfile")
+		file, err := os.CreateTemp("", "Gemfile")
 		Expect(err).NotTo(HaveOccurred())
 		defer file.Close()
 
@@ -35,28 +34,24 @@ func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
 	context("Parse", func() {
 		context("when using thin", func() {
 			it("parses correctly", func() {
-				const GEMFILE_CONTENTS = `source 'https://rubygems.org'
+				Expect(os.WriteFile(path, []byte(`source 'https://rubygems.org'
 
-gem 'thin'`
-
-				Expect(ioutil.WriteFile(path, []byte(GEMFILE_CONTENTS), 0644)).To(Succeed())
+gem 'thin'`), 0600)).To(Succeed())
 
 				hasThin, err := parser.Parse(path)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(hasThin).To(Equal(true))
+				Expect(hasThin).To(BeTrue())
 			})
 		})
 
 		context("when not using thin", func() {
 			it("parses correctly", func() {
-				const GEMFILE_CONTENTS = `source 'https://rubygems.org'
-ruby '~> 2.0'`
-
-				Expect(ioutil.WriteFile(path, []byte(GEMFILE_CONTENTS), 0644)).To(Succeed())
+				Expect(os.WriteFile(path, []byte(`source 'https://rubygems.org'
+ruby '~> 2.0'`), 0600)).To(Succeed())
 
 				hasThin, err := parser.Parse(path)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(hasThin).To(Equal(false))
+				Expect(hasThin).To(BeFalse())
 			})
 		})
 
@@ -68,7 +63,7 @@ ruby '~> 2.0'`
 			it("returns all false", func() {
 				hasThin, err := parser.Parse(path)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(hasThin).To(Equal(false))
+				Expect(hasThin).To(BeFalse())
 			})
 		})
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
All buildpacks that have upgraded to the latest version of `packit` should be able to run with buildpack API 0.6.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
