### PR TITLE
Add support for thin config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@
 
 The Thin CNB sets the start command for a given ruby application that runs on a Thin server.
 
+## Configuration
+
+### Thin config file
+
+It is possible to provide a thin config file to be passed to thin as part of
+the start command (via the `thin -C <some-file>` option).
+
+The `BP_THIN_CONFIG_LOCATION` environment variable allows you to specify the
+location of a thin config file. This can either be an absolute path, or a
+relative path (relative to the application root directory).
+
+If `BP_THIN_CONFIG_LOCATION` is unset and there is a `thin.yml` file in the
+application root directory, this file will be provided to thin as part of the
+start command.
+
+If `BP_THIN_CONFIG_LOCATION` is set to a value that does not correspond to a
+file, the build phase will fail.
+
+### `buildpack.yml` Configurations
+
+There are no extra configurations for this buildpack based on `buildpack.yml`.
+
 ## Integration
 
 This CNB writes a start command, so there's currently no scenario we can
@@ -16,7 +38,3 @@ To package this buildpack for consumption:
 $ ./scripts/package.sh
 ```
 This builds the buildpack's source using GOOS=linux by default. You can supply another value as the first argument to package.sh.
-
-## `buildpack.yml` Configurations
-
-There are no extra configurations for this buildpack based on `buildpack.yml`.

--- a/build.go
+++ b/build.go
@@ -1,7 +1,12 @@
 package thin
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/paketo-buildpacks/packit/v2"
+	"github.com/paketo-buildpacks/packit/v2/fs"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 )
 
@@ -9,8 +14,38 @@ func Build(logger scribe.Emitter) packit.BuildFunc {
 	return func(context packit.BuildContext) (packit.BuildResult, error) {
 		logger.Title("%s %s", context.BuildpackInfo.Name, context.BuildpackInfo.Version)
 
+		thinConfigFilepath := filepath.Join(context.WorkingDir, "thin.yml")
+
+		envVarThinConfigFilepath := os.Getenv("BP_THIN_CONFIG_LOCATION")
+		if envVarThinConfigFilepath != "" {
+			if !filepath.IsAbs(envVarThinConfigFilepath) {
+				envVarThinConfigFilepath = filepath.Join(context.WorkingDir, envVarThinConfigFilepath)
+			}
+
+			envVarThinConfigFilepathExists, err := fs.Exists(envVarThinConfigFilepath)
+			if err != nil {
+				return packit.BuildResult{}, err
+			}
+
+			if !envVarThinConfigFilepathExists {
+				return packit.BuildResult{}, packit.Fail.WithMessage("thin config file does not exist at: %s", envVarThinConfigFilepath)
+			}
+
+			thinConfigFilepath = envVarThinConfigFilepath
+		}
+
+		exists, err := fs.Exists(thinConfigFilepath)
+		if err != nil {
+			return packit.BuildResult{}, err
+		}
+
+		args := "bundle exec thin"
+		if exists {
+			args = args + fmt.Sprintf(" -C %s", thinConfigFilepath)
+		}
+
 		// 3000 is the default thin port
-		args := `bundle exec thin -p "${PORT:-3000}" start`
+		args = args + ` -p "${PORT:-3000}" start`
 		processes := []packit.Process{
 			{
 				Type:    "web",

--- a/build.go
+++ b/build.go
@@ -14,25 +14,23 @@ func Build(logger scribe.Emitter) packit.BuildFunc {
 	return func(context packit.BuildContext) (packit.BuildResult, error) {
 		logger.Title("%s %s", context.BuildpackInfo.Name, context.BuildpackInfo.Version)
 
-		thinConfigFilepath := filepath.Join(context.WorkingDir, "thin.yml")
+               thinConfigFilepath := os.Getenv("BP_THIN_CONFIG_LOCATION")
+                if thinConfigFilepath != "" {
+                        if !filepath.IsAbs(thinConfigFilepath) {
+                                thinConfigFilepath = filepath.Join(context.WorkingDir, thinConfigFilepath)
+                        }
 
-		envVarThinConfigFilepath := os.Getenv("BP_THIN_CONFIG_LOCATION")
-		if envVarThinConfigFilepath != "" {
-			if !filepath.IsAbs(envVarThinConfigFilepath) {
-				envVarThinConfigFilepath = filepath.Join(context.WorkingDir, envVarThinConfigFilepath)
-			}
+                        thinConfigFilepathExists, err := fs.Exists(thinConfigFilepath)
+                        if err != nil {
+                                return packit.BuildResult{}, err
+                        }
 
-			envVarThinConfigFilepathExists, err := fs.Exists(envVarThinConfigFilepath)
-			if err != nil {
-				return packit.BuildResult{}, err
-			}
-
-			if !envVarThinConfigFilepathExists {
-				return packit.BuildResult{}, packit.Fail.WithMessage("thin config file does not exist at: %s", envVarThinConfigFilepath)
-			}
-
-			thinConfigFilepath = envVarThinConfigFilepath
-		}
+                        if !thinConfigFilepathExists {
+                                return packit.BuildResult{}, packit.Fail.WithMessage("thin config file does not exist at: %s", thinConfigFilepath)
+                        }
+                } else {
+                        thinConfigFilepath = filepath.Join(context.WorkingDir, "thin.yml")
+                }
 
 		exists, err := fs.Exists(thinConfigFilepath)
 		if err != nil {

--- a/build_test.go
+++ b/build_test.go
@@ -2,7 +2,9 @@ package thin_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/paketo-buildpacks/packit/v2"
@@ -22,7 +24,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		cnbDir     string
 		buffer     *bytes.Buffer
 
-		build packit.BuildFunc
+		build        packit.BuildFunc
+		buildContext packit.BuildContext
 	)
 
 	it.Before(func() {
@@ -40,16 +43,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		logger := scribe.NewEmitter(buffer)
 
 		build = thin.Build(logger)
-	})
-
-	it.After(func() {
-		Expect(os.RemoveAll(layersDir)).To(Succeed())
-		Expect(os.RemoveAll(cnbDir)).To(Succeed())
-		Expect(os.RemoveAll(workingDir)).To(Succeed())
-	})
-
-	it("returns a result that provides a thin start command", func() {
-		result, err := build(packit.BuildContext{
+		buildContext = packit.BuildContext{
 			WorkingDir: workingDir,
 			CNBPath:    cnbDir,
 			Stack:      "some-stack",
@@ -61,7 +55,17 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Entries: []packit.BuildpackPlanEntry{},
 			},
 			Layers: packit.Layers{Path: layersDir},
-		})
+		}
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(layersDir)).To(Succeed())
+		Expect(os.RemoveAll(cnbDir)).To(Succeed())
+		Expect(os.RemoveAll(workingDir)).To(Succeed())
+	})
+
+	it("returns a result that provides a thin start command", func() {
+		result, err := build(buildContext)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(result).To(Equal(packit.BuildResult{
@@ -84,5 +88,210 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(buffer.String()).To(ContainSubstring("Some Buildpack some-version"))
 		Expect(buffer.String()).To(ContainSubstring("Assigning launch processes:"))
+	})
+
+	context("when a thin.yml file exists in the working directory", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filepath.Join(workingDir, "thin.yml"), []byte{}, os.ModePerm)).To(Succeed())
+		})
+
+		it("returns a result with that file provided to the thin start command", func() {
+			result, err := build(buildContext)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal(packit.BuildResult{
+				Plan: packit.BuildpackPlan{
+					Entries: nil,
+				},
+				Layers: nil,
+				Launch: packit.LaunchMetadata{
+					Processes: []packit.Process{
+						{
+							Type:    "web",
+							Command: "bash",
+							Args: []string{
+								"-c",
+								fmt.Sprintf(`bundle exec thin -C %s -p "${PORT:-3000}" start`, filepath.Join(workingDir, "thin.yml")),
+							},
+							Default: true,
+							Direct:  true,
+						},
+					},
+				},
+			}))
+		})
+	})
+
+	context("when the BP_THIN_CONFIG_LOCATION environment variable points to a valid file", func() {
+		it.Before(func() {
+			thinConfigFilepath := filepath.Join(workingDir, "some-thin-config.yml")
+			Expect(os.WriteFile(thinConfigFilepath, []byte{}, os.ModePerm)).To(Succeed())
+			Expect(os.Setenv("BP_THIN_CONFIG_LOCATION", thinConfigFilepath)).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BP_THIN_CONFIG_LOCATION")).To(Succeed())
+		})
+
+		it("returns a result with that file provided to the thin start command", func() {
+			result, err := build(buildContext)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal(packit.BuildResult{
+				Plan: packit.BuildpackPlan{
+					Entries: nil,
+				},
+				Layers: nil,
+				Launch: packit.LaunchMetadata{
+					Processes: []packit.Process{
+						{
+							Type:    "web",
+							Command: "bash",
+							Args: []string{
+								"-c",
+								fmt.Sprintf(`bundle exec thin -C %s -p "${PORT:-3000}" start`, filepath.Join(workingDir, "some-thin-config.yml")),
+							},
+							Default: true,
+							Direct:  true,
+						},
+					},
+				},
+			}))
+		})
+
+		context("when the BP_THIN_CONFIG_LOCATION environment variable is a relative path", func() {
+			it.Before(func() {
+				relativeFilepath := filepath.Join("some-dir", "some-thin-config.yml")
+				Expect(os.MkdirAll(filepath.Join(workingDir, "some-dir"), os.ModePerm)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, "some-dir", "some-thin-config.yml"), []byte{}, os.ModePerm)).To(Succeed())
+				Expect(os.Setenv("BP_THIN_CONFIG_LOCATION", relativeFilepath)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BP_THIN_CONFIG_LOCATION")).To(Succeed())
+			})
+
+			it("returns a result with that file relative to the working directory", func() {
+				result, err := build(buildContext)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(result).To(Equal(packit.BuildResult{
+					Plan: packit.BuildpackPlan{
+						Entries: nil,
+					},
+					Layers: nil,
+					Launch: packit.LaunchMetadata{
+						Processes: []packit.Process{
+							{
+								Type:    "web",
+								Command: "bash",
+								Args: []string{
+									"-c",
+									fmt.Sprintf(`bundle exec thin -C %s -p "${PORT:-3000}" start`, filepath.Join(workingDir, "some-dir", "some-thin-config.yml")),
+								},
+								Default: true,
+								Direct:  true,
+							},
+						},
+					},
+				}))
+			})
+		})
+	})
+
+	context("when both the BP_THIN_CONFIG_LOCATION env var is set and a thin.yml file is present", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filepath.Join(workingDir, "thin.yml"), []byte{}, os.ModePerm)).To(Succeed())
+
+			envVarThinConfigFilepath := filepath.Join(workingDir, "some-thin-config.yml")
+			Expect(os.WriteFile(envVarThinConfigFilepath, []byte{}, os.ModePerm)).To(Succeed())
+			Expect(os.Setenv("BP_THIN_CONFIG_LOCATION", envVarThinConfigFilepath)).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BP_THIN_CONFIG_LOCATION")).To(Succeed())
+		})
+
+		it("prioritizes the environment variable", func() {
+			result, err := build(buildContext)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal(packit.BuildResult{
+				Plan: packit.BuildpackPlan{
+					Entries: nil,
+				},
+				Layers: nil,
+				Launch: packit.LaunchMetadata{
+					Processes: []packit.Process{
+						{
+							Type:    "web",
+							Command: "bash",
+							Args: []string{
+								"-c",
+								fmt.Sprintf(`bundle exec thin -C %s -p "${PORT:-3000}" start`, filepath.Join(workingDir, "some-thin-config.yml")),
+							},
+							Default: true,
+							Direct:  true,
+						},
+					},
+				},
+			}))
+		})
+	})
+
+	context("failure cases", func() {
+		context("when there is an error determining if the default thin config file exists", func() {
+			it.Before(func() {
+				envVarThinConfigFilepath := filepath.Join(workingDir, "some-thin-config.yml")
+				Expect(os.WriteFile(envVarThinConfigFilepath, []byte{}, os.ModePerm)).To(Succeed())
+				Expect(os.Setenv("BP_THIN_CONFIG_LOCATION", envVarThinConfigFilepath)).To(Succeed())
+
+				Expect(os.Chmod(workingDir, 0000)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Chmod(workingDir, os.ModePerm)).To(Succeed())
+			})
+
+			it("returns an error", func() {
+				_, err := build(buildContext)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		context("when there is an error determining if the env var thin config file exists", func() {
+			it.Before(func() {
+				envVarThinConfigFilepath := filepath.Join(workingDir, "some-thin-config.yml")
+				Expect(os.WriteFile(envVarThinConfigFilepath, []byte{}, os.ModePerm)).To(Succeed())
+				Expect(os.Setenv("BP_THIN_CONFIG_LOCATION", envVarThinConfigFilepath)).To(Succeed())
+
+				Expect(os.Chmod(workingDir, 0000)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Chmod(workingDir, os.ModePerm)).To(Succeed())
+				Expect(os.Unsetenv("BP_THIN_CONFIG_LOCATION")).To(Succeed())
+			})
+
+			it("returns an error", func() {
+				_, err := build(buildContext)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		context("when the BP_THIN_CONFIG_LOCATION environment variable points to a non-existent file", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BP_THIN_CONFIG_LOCATION", filepath.Join(workingDir, "non-existent-file"))).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BP_THIN_CONFIG_LOCATION")).To(Succeed())
+			})
+
+			it("returns an error", func() {
+				_, err := build(buildContext)
+				Expect(err).To(MatchError(packit.Fail.WithMessage("thin config file does not exist at: %s", filepath.Join(workingDir, "non-existent-file"))))
+			})
+		})
 	})
 }

--- a/init_test.go
+++ b/init_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestUnitThin(t *testing.T) {
-	suite := spec.New("thin", spec.Report(report.Terminal{}), spec.Parallel())
+	suite := spec.New("thin", spec.Report(report.Terminal{}), spec.Sequential())
 	suite("Build", testBuild)
 	suite("Detect", testDetect)
 	suite("GemfileParser", testGemfileParser)

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sclevine/spec/report"
 
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 )
 
 var settings struct {
@@ -44,6 +45,10 @@ var settings struct {
 }
 
 func TestIntegration(t *testing.T) {
+	// Do not truncate Gomega matcher output
+	// The buildpack output text can be large and we often want to see all of it.
+	format.MaxLength = 0
+
 	Expect := NewWithT(t).Expect
 
 	root, err := filepath.Abs("./..")
@@ -86,5 +91,6 @@ func TestIntegration(t *testing.T) {
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("SimpleApp", testSimpleApp)
 	suite("RackApp", testRackApp)
+	suite("ThinConfigFile", testThinConfigFile)
 	suite.Run(t)
 }

--- a/integration/testdata/thin_config_file/Gemfile
+++ b/integration/testdata/thin_config_file/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+ruby '~> 2.0'
+
+gem 'thin'
+gem 'sinatra'

--- a/integration/testdata/thin_config_file/README.md
+++ b/integration/testdata/thin_config_file/README.md
@@ -1,0 +1,1 @@
+thin - sinatra web app

--- a/integration/testdata/thin_config_file/app.rb
+++ b/integration/testdata/thin_config_file/app.rb
@@ -1,0 +1,6 @@
+require 'sinatra'
+configure { set :server, :thin }
+
+get '/' do
+  'Hello world!'
+end

--- a/integration/testdata/thin_config_file/config.ru
+++ b/integration/testdata/thin_config_file/config.ru
@@ -1,0 +1,3 @@
+#\ -s thin
+require './app'
+run Sinatra::Application

--- a/integration/testdata/thin_config_file/thin.yml
+++ b/integration/testdata/thin_config_file/thin.yml
@@ -1,0 +1,2 @@
+---
+debug: true

--- a/integration/thin_config_file_test.go
+++ b/integration/thin_config_file_test.go
@@ -1,0 +1,96 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testThinConfigFile(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack()
+		docker = occam.NewDocker()
+	})
+
+	context("when building an app with a thin config file", func() {
+		var (
+			image     occam.Image
+			container occam.Container
+
+			name   string
+			source string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		context("a thin config file is provided", func() {
+			it("creates a working OCI image with the thin config present in the start command", func() {
+				var err error
+				source, err = occam.Source(filepath.Join("testdata", "thin_config_file"))
+				Expect(err).NotTo(HaveOccurred())
+
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithBuildpacks(
+						settings.Buildpacks.MRI.Online,
+						settings.Buildpacks.Bundler.Online,
+						settings.Buildpacks.BundleInstall.Online,
+						settings.Buildpacks.Thin.Online,
+					).
+					WithPullPolicy("never").
+					Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
+
+				container, err = docker.Container.Run.
+					WithPublish("3000").
+					WithPublishAll().
+					WithTTY(). // required for thin to display initialization logs which is what we assert on later
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(container).Should(BeAvailable())
+				Eventually(container).Should(Serve(ContainSubstring("Hello world!")).OnPort(3000))
+
+				Expect(logs).To(ContainLines(
+					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
+					"  Assigning launch processes:",
+					`    web (default): bash -c bundle exec thin -C /workspace/thin.yml -p "${PORT:-3000}" start`,
+				))
+
+				Eventually(func() string {
+					cLogs, err := docker.Container.Logs.Execute(container.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return cLogs.String()
+				}).Should(
+					ContainSubstring("Debugging ON"),
+				)
+			})
+		})
+	})
+}


### PR DESCRIPTION
## Summary
<!-- A short explanation of the proposed change -->

Add support for a thin config file.

Look for a file defined by the `BP_THIN_CONFIG_LOCATION` environment variable, falling back to a default location of `config.yml` in the working directory (i.e. `/workspace/config.yml`) if the environment variable is unset or empty.
- Prioritize the environment variable over the default filepath.
- If the filepath provided via `BP_THIN_CONFIG_LOCATION` is a relative path, assume that it is relative to the working directory. Otherwise take the absolute path as provided.
- If the `BP_THIN_CONFIG_LOCATION` environment variable points to a filepath (relative or absolute) that does not exist, fail with error rather than falling back to the default location. This enables fast-fail during build for invalid values of `BP_THIN_CONFIG_LOCATION`, rather than silently ignoring the failure.
- If the environment variable is empty or unset, and there is no file at the default location of `/workspace/config.yml`, then create a start command with no config file. This preserves the current behavior.

Closes #6 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
