### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Thin Paketo Cloud Native Buildpack
+# Thin Paketo Buildpack for Cloud Native
 
 ## `gcr.io/paketo-buildpacks/thin`
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/thin"
   id = "paketo-buildpacks/thin"
   keywords = ["ruby", "thin"]
-  name = "Paketo Thin Buildpack"
+  name = "Paketo Buildpack for Thin"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"


### PR DESCRIPTION
Renames 'Paketo Thin Buildpack' to 'Paketo Buildpack for Thin'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
